### PR TITLE
仮登録時のメール送信バグ解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ config/initializers/secret_token.rb
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed
-.env
+.env.*
 
 ## Environment normalization:
 /.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'capybara'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erubis (2.7.0)
@@ -226,6 +230,7 @@ DEPENDENCIES
   chartkick (~> 2.0)
   coffee-rails (~> 4.2)
   devise (~> 4.0, < 4.3)
+  dotenv-rails
   enum_help
   factory_girl_rails
   jbuilder (~> 2.5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv::Railtie.load
+
 module ESal
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
```
サーバ設定の環境変数ではうまく認証されなかったため、gem「dotenv」を使用し、「.env.~」の環境変数ファイルをアプリケーションルートに配置することで、認証エラーを回避。

上記ファイルはGitの管理対象外ファイルのため、slackで連携します。
```