### PR TITLE
Sort main_categories on the edit page.

### DIFF
--- a/app/views/e_sal/original_categories/_form.html.erb-20170728
+++ b/app/views/e_sal/original_categories/_form.html.erb-20170728
@@ -15,7 +15,7 @@
             <%= f.text_field :name_url, hide_label: true, class: "js-disabled-enter", placeholder: "URLに使用されますので、慎重に入力してください。", disabled: @has_tutorials %>
   
             <div><span>メインカテゴリ</span></div>
-            <%= f.select :main_category_id, @main_categories.sort_by(&:id).map{|m| [m.name, m.id] }, { prompt: "選択してください", hide_label: true }, { disabled: @has_tutorials } %>
+            <%= f.select :main_category_id, @main_categories.map{|m| [m.name, m.id] }, { prompt: "選択してください", hide_label: true }, { disabled: @has_tutorials } %>
   
             <%= f.submit "更新する", class: "btn btn-success pull-right" %>
           <% end %>


### PR DESCRIPTION
今日は メインカテゴリを整理したわけですが…

マイカテゴリの編集画面でSelect Boxを開くと
表示順が　すげー残念な状態になってたので、
id順でsort_byしてから 出力をするように変更。

